### PR TITLE
Correct detection with negative margins.

### DIFF
--- a/flexmenu.js
+++ b/flexmenu.js
@@ -54,7 +54,7 @@
 				$lastItem = $this.find('li:last-child'),
 				numItems = $this.find('li').length,
 				firstItemTop = Math.floor($firstItem.offset().top),
-				firstItemHeight = Math.floor($firstItem.height()),
+				firstItemHeight = Math.floor($firstItem.outerHeight(true)),
 				$lastChild,
 				keepLooking,
 				$moreItem,


### PR DESCRIPTION
Our navigation had <li> with a negative bottom margin. flexMenu didn't pick this up. This commit fixes that. 

Tested with jquery 1.7 and latest stable Chrome, Firefox, and IE8. 
