### PR TITLE
Use universal module definition for AMD-compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Finally, call flexMenu on an unordered list that contains your menu items:
 $('ul.menu.flex').flexMenu();
 ```
 
+###AMD/RequireJS
+
+The plugin can be loaded using an AMD loader such as RequireJS:
+
+```javascript
+require(['jquery', 'flexmenu'], function ($) {
+    $('ul.menu.flex').flexMenu();
+});
+```
+
 ##Dependencies
 
 ###jQuery

--- a/demo-subnav.html
+++ b/demo-subnav.html
@@ -10,7 +10,7 @@
 	<meta name="viewport" content="width=device-width">
 	<link rel="stylesheet" href="demo.css">
 	<style>
-		/* Sub-menu styles 
+		/* Sub-menu styles
 		** Not included here: CSS for when the sub-menu appears in .menu-flex. */
 		.menu-sub {
 			display: none;
@@ -24,7 +24,7 @@
 		}
 	</style>
 	<script src="modernizr.custom.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Quantico:700' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Quantico:700' rel='stylesheet' type='text/css'>
 </head>
 <body>
 
@@ -32,7 +32,7 @@
 		<h1>flexMenu</h1>
 		<p>flexMenu is a jQuery plugin that lets you create responsive menu bars. When there's only space to display some of the items in the menu, the rest of the items collapse into a "more" drop-down. When there's only space to display one or two items, all the items collapse into a "menu" drop-down. Try it out - just resize the page, or view it on a smartphone!</p>
 	</div>
-	
+
 	<div role="main" class="main">
 
 		<ul class="menu flex">
@@ -111,11 +111,11 @@
 		</p>
 	</div>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 
 	<script src="flexmenu.min.js"></script>
 
-	<script type="text/javascript">
+	<script>
 		$('ul.menu.flex').flexMenu();
 		$('ul.menu.flex-multi').flexMenu({
 			showOnHover: false

--- a/demo.html
+++ b/demo.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="demo.css">
 
 	<script src="modernizr.custom.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Quantico:700' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Quantico:700' rel='stylesheet' type='text/css'>
 </head>
 <body>
 
@@ -19,7 +19,7 @@
 		<h1>flexMenu</h1>
 		<p>flexMenu is a jQuery plugin that lets you create responsive menu bars. When there's only space to display some of the items in the menu, the rest of the items collapse into a "more" drop-down. When there's only space to display one or two items, all the items collapse into a "menu" drop-down. Try it out - just resize the page, or view it on a smartphone!</p>
 	</div>
-	
+
 	<div role="main" class="main">
 
 		<ul class="menu flex">
@@ -89,11 +89,11 @@
 		</p>
 	</div>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 
 	<script src="flexmenu.min.js"></script>
 
-	<script type="text/javascript">
+	<script>
 		$('ul.menu.flex').flexMenu();
 		$('ul.menu.flex-multi').flexMenu({
 			showOnHover: false

--- a/flexmenu.js
+++ b/flexmenu.js
@@ -3,7 +3,15 @@
 	Description: If a list is too long for all items to fit on one line, display a popup menu instead.
 	Dependencies: jQuery, Modernizr (optional). Without Modernizr, the menu can only be shown on click (not hover). */
 
-(function ($) {
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(['jquery'], factory);
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
 	var flexObjects = [], // Array of all flexMenu objects
 		resizeTimeout;
 	// When the page is resized, adjust the flexMenus.
@@ -134,4 +142,4 @@
 			}
 		});
 	};
-})(jQuery);
+}));


### PR DESCRIPTION
Wraps the plugin in [UMD](https://github.com/umdjs/umd) to allow it to be loaded by an AMD loader (e.g. RequireJS) and without.

It would be advisable to increment the minor version number (to 1.2, for instance) if this change is accepted.

Also the demo pages have been changed to use HTTPS to load from the Google CDNs.